### PR TITLE
feat: add passing score on try out segment test

### DIFF
--- a/app/Http/Controllers/Admin/TryoutController.php
+++ b/app/Http/Controllers/Admin/TryoutController.php
@@ -94,6 +94,9 @@ class TryoutController extends Controller
         foreach ($tryout->tryoutSegments as $key => $data) {
             $segmentTests = [];
             foreach ($data['tryoutSegmentTests'] as $key1 => $data1) {
+                if($data1['passing_score'] == NULL){
+                    $data1['passing_score'] = $data1['test']['passing_score'];
+                }
                 $segmentTests[] = [
                     'segment_test_uuid' => $data1['uuid'],
                     'test_uuid' => $data1['test_uuid'],
@@ -103,7 +106,7 @@ class TryoutController extends Controller
                     'test_type' => $data1['test']['test_type'],
                     'test_title' => $data1['test']['test_title'],
                     'test_student_title_display' => $data1['test']['student_title_display'],
-                    'test_passing_score' => $data1['test']['passing_score'],
+                    'test_passing_score' => $data1['passing_score'],
                     'test_category' => $data1['test']['test_category'],
                     'test_status' => $data1['test']['status'],
                 ];
@@ -214,6 +217,7 @@ class TryoutController extends Controller
             'segments.*.tests.*.attempt' => 'required',
             'segments.*.tests.*.duration' => 'required',
             'segments.*.tests.*.max_point' => 'required',
+            'segmentes.*.tests.*.test_passing_score' => 'required'
         ];
         $validator = Validator::make($request->all(), $validate);
 
@@ -246,6 +250,7 @@ class TryoutController extends Controller
                     'attempt' => $test['attempt'],
                     'duration' => $test['duration'],
                     'max_point' => $test['max_point'],
+                    'passing_score' => $test['test_passing_score']
                 ]);
             }
         }

--- a/app/Models/TryoutSegmentTest.php
+++ b/app/Models/TryoutSegmentTest.php
@@ -23,7 +23,8 @@ class TryoutSegmentTest extends Model
         'test_uuid',
         'attempt',
         'duration',
-        'max_point'
+        'max_point',
+        'passing_score',
     ];
 
     public function test()

--- a/database/migrations/2025_02_03_033750_add_passing_score_to_try_out_segment_test_table.php
+++ b/database/migrations/2025_02_03_033750_add_passing_score_to_try_out_segment_test_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddPassingScoreToTryOutSegmentTestTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tryout_segment_tests', function (Blueprint $table) {
+            $table->integer('passing_score')->nullable()->comment('Passing score for the test');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tryout_segment_tests', function (Blueprint $table) {
+        $table->dropColumn('passing_score');
+        });
+    }
+}


### PR DESCRIPTION
### PASSING SCORE FEATURE ON TRY OUT TEST SEGMENT

When we add a test as a try out segment, we can set the passing score value which will be used as an indicator for determining user graduation.

The passing score in the try out can be set differently from the passing score set in the test endpoint, or if it is not filled in then by default it will follow the passing_score value in the test table

![image](https://github.com/user-attachments/assets/7fb8a26c-2e25-4bea-bf29-29c88167bf6c)
![image](https://github.com/user-attachments/assets/8af93a5d-8bf2-4eba-9f80-997ba48ed4d9)
![image](https://github.com/user-attachments/assets/2cb10c8f-5550-4d36-882e-29cadae1ef23)
